### PR TITLE
Bug fix on export command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -120,7 +120,7 @@ public class StringUtil {
         requireNonNull(s);
 
         try {
-            return s.contains(".xml") && s.matches("[\\p{Alnum}][\\p{Graph} ]*");
+            return s.matches("[\\p{Alnum}][\\p{Graph} ]*[.xml]$");
         } catch (IllegalArgumentException ipe) {
             return false;
         }

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -38,5 +38,7 @@ public class ExportCommandParserTest {
                 ExportCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "C/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 ExportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "docs/ab.xmla", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ExportCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
isFilePath regex changed to "[\\p{Alnum}][\\p{Graph} ]*[.xml]$" to ensure the exported addressbook file is in xml format.